### PR TITLE
Limit shadow token length

### DIFF
--- a/aws_iot_device.gemspec
+++ b/aws_iot_device.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0", ">= 1.10" 
   spec.add_development_dependency "rspec", "~> 3.5.0", ">= 3.5.0"
 
-  spec.add_runtime_dependency "facets", "~> 3.1.0", ">= 3.1.0"
+  #spec.add_runtime_dependency "facets", "~> 3.1.0", ">= 3.1.0"
   spec.add_runtime_dependency "json", "~> 2.0.2", ">= 2.0.2"
   spec.add_runtime_dependency "paho-mqtt", "~> 1.0.0", ">= 1.0.0"
   spec.add_runtime_dependency "timers", "~> 4.1.1", ">= 4.1.1"

--- a/aws_iot_device.gemspec
+++ b/aws_iot_device.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0", ">= 1.10" 
   spec.add_development_dependency "rspec", "~> 3.5.0", ">= 3.5.0"
 
-  #spec.add_runtime_dependency "facets", "~> 3.1.0", ">= 3.1.0"
+  spec.add_runtime_dependency "facets", "~> 3.1.0", ">= 3.1.0"
   spec.add_runtime_dependency "json", "~> 2.0.2", ">= 2.0.2"
   spec.add_runtime_dependency "paho-mqtt", "~> 1.0.0", ">= 1.0.0"
   spec.add_runtime_dependency "timers", "~> 4.1.1", ">= 4.1.1"

--- a/aws_iot_device.gemspec
+++ b/aws_iot_device.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "facets", "~> 3.1.0", ">= 3.1.0"
   spec.add_runtime_dependency "json", "~> 2.0.2", ">= 2.0.2"
-  spec.add_runtime_dependency "paho-mqtt", "~> 1.0.0", ">= 1.0.0"
+  #spec.add_runtime_dependency "paho-mqtt", "~> 1.0.0", ">= 1.0.0"
   spec.add_runtime_dependency "timers", "~> 4.1.1", ">= 4.1.1"
 end

--- a/lib/aws_iot_device/mqtt_adapter.rb
+++ b/lib/aws_iot_device/mqtt_adapter.rb
@@ -1,4 +1,4 @@
-#require 'facets'
+require 'facets'
 require 'aws_iot_device/mqtt_adapter/client'
 
 module AwsIotDevice

--- a/lib/aws_iot_device/mqtt_adapter.rb
+++ b/lib/aws_iot_device/mqtt_adapter.rb
@@ -1,4 +1,4 @@
-require 'facets'
+#require 'facets'
 require 'aws_iot_device/mqtt_adapter/client'
 
 module AwsIotDevice

--- a/lib/aws_iot_device/mqtt_shadow_client/token_creator.rb
+++ b/lib/aws_iot_device/mqtt_shadow_client/token_creator.rb
@@ -11,7 +11,11 @@ module AwsIotDevice
       ### When token time run out or the actions have been treated token should deleted.
 
       def initialize(shadow_name, client_id)
-        @shadow_name = shadow_name[0..15]
+        if shadow_name.length > 16
+          @shadow_name = shadow_name[0..15]
+        else
+          @shadow_name = shadow_name
+        end
         @client_id = client_id
         @sequence_number = 0
       end

--- a/lib/aws_iot_device/mqtt_shadow_client/token_creator.rb
+++ b/lib/aws_iot_device/mqtt_shadow_client/token_creator.rb
@@ -11,7 +11,7 @@ module AwsIotDevice
       ### When token time run out or the actions have been treated token should deleted.
 
       def initialize(shadow_name, client_id)
-        @shadow_name = shadow_name
+        @shadow_name = shadow_name[0..15]
         @client_id = client_id
         @sequence_number = 0
       end


### PR DESCRIPTION
AWS limits tokens to be 64 bytes or fewer.  This change to the TokenCreator class uses at most the first 16 characters of the shadow name to incorporate into the token.  The token is then shorter than the 64 character limit.  A long shadow name can otherwise put the token over the limit.